### PR TITLE
当客户端没有启动yarn session的时候会报空指针错误

### DIFF
--- a/flinkx-launcher/src/main/java/com/dtstack/flinkx/launcher/ClusterClientFactory.java
+++ b/flinkx-launcher/src/main/java/com/dtstack/flinkx/launcher/ClusterClientFactory.java
@@ -122,7 +122,7 @@ public class ClusterClientFactory {
 
                 }
 
-                if(StringUtils.isEmpty(applicationId.toString())) {
+                if(applicationId != null && StringUtils.isEmpty(applicationId.toString())) {
                     throw new RuntimeException("No flink session found on yarn cluster.");
                 }
 


### PR DESCRIPTION
我在开始执行on yarn的时候 没有启动 yarn session
最后才发现是没有启动yarn session