### PR TITLE
byteWrite metric fix

### DIFF
--- a/flinkx-core/src/main/java/com/dtstack/flinkx/inputformat/RichInputFormat.java
+++ b/flinkx-core/src/main/java/com/dtstack/flinkx/inputformat/RichInputFormat.java
@@ -172,7 +172,7 @@ public abstract class RichInputFormat extends org.apache.flink.api.common.io.Ric
             numReadCounter.add(1);
         }
         if(bytesReadCounter!=null){
-            bytesReadCounter.add(internalRow.toString().length());
+            bytesReadCounter.add(internalRow.toString().getBytes().length);
         }
         return internalRow;
     }

--- a/flinkx-core/src/main/java/com/dtstack/flinkx/outputformat/RichOutputFormat.java
+++ b/flinkx-core/src/main/java/com/dtstack/flinkx/outputformat/RichOutputFormat.java
@@ -412,7 +412,7 @@ public abstract class RichOutputFormat extends org.apache.flink.api.common.io.Ri
 
         updateDuration();
         if(bytesWriteCounter!=null){
-            bytesWriteCounter.add(row.toString().length());
+            bytesWriteCounter.add(row.toString().getBytes().length);
         }
     }
 

--- a/flinkx-hive/flinkx-hive-writer/src/main/java/com/dtstack/flinkx/hive/writer/HiveOutputFormat.java
+++ b/flinkx-hive/flinkx-hive-writer/src/main/java/com/dtstack/flinkx/hive/writer/HiveOutputFormat.java
@@ -194,8 +194,8 @@ public class HiveOutputFormat extends RichOutputFormat {
         Row rowData = setChannelInformation(event, row.getField(1), formatPair.getSecond().getColumns());
         formatPair.getFirst().writeRecord(rowData);
         //row包含map嵌套的数据内容和channel， 而rowData是非常简单的纯数据，此处补上数据差额
-        if(bytesWriteCounter != null){
-            bytesWriteCounter.add(row.toString().length() - rowData.toString().length());
+        if (bytesWriteCounter != null) {
+            bytesWriteCounter.add(row.toString().getBytes().length - rowData.toString().getBytes().length);
         }
     }
 


### PR DESCRIPTION
发现在 https://github.com/DTStack/flinkx/blob/1.8_release/docs/statistics.md 页面显示byteWrite统计的是 累计写入数据字节数，但是代码中好像是长度？是不是改成getBytes().length 更合适一点？

