### PR TITLE
插入异常被吞掉BUG

### DIFF
--- a/flinkx-core/src/main/java/com/dtstack/flinkx/outputformat/BaseRichOutputFormat.java
+++ b/flinkx-core/src/main/java/com/dtstack/flinkx/outputformat/BaseRichOutputFormat.java
@@ -350,9 +350,7 @@ public abstract class BaseRichOutputFormat extends org.apache.flink.api.common.i
             if(dirtyDataManager == null && errCounter.getLocalValue() % LOG_PRINT_INTERNAL == 0){
                 LOG.error(e.getMessage());
             }
-            if(DtLogger.isEnableTrace()){
-                LOG.trace("write error row, row = {}, e = {}", row.toString(), ExceptionUtil.getErrorMessage(e));
-            }
+            LOG.error("write error row, row = {}, e = {}", row.toString(), ExceptionUtil.getErrorMessage(e));
         }
     }
 

--- a/flinkx-mongodb/flinkx-mongodb-reader/src/main/java/com/dtstack/flinkx/mongodb/reader/MongodbInputFormatBuilder.java
+++ b/flinkx-mongodb/flinkx-mongodb-reader/src/main/java/com/dtstack/flinkx/mongodb/reader/MongodbInputFormatBuilder.java
@@ -21,6 +21,7 @@ package com.dtstack.flinkx.mongodb.reader;
 import com.dtstack.flinkx.inputformat.BaseRichInputFormatBuilder;
 import com.dtstack.flinkx.mongodb.MongodbConfig;
 import com.dtstack.flinkx.reader.MetaColumn;
+import org.bson.json.JsonWriterSettings;
 
 import java.util.List;
 
@@ -56,4 +57,19 @@ public class MongodbInputFormatBuilder extends BaseRichInputFormatBuilder {
             throw new UnsupportedOperationException("This plugin not support restore from failed state");
         }
     }
+
+    // bson转json格式设置
+    public static JsonWriterSettings getJsonWriterSettings() {
+        JsonWriterSettings jsonWriterSettings = JsonWriterSettings.builder()
+                .dateTimeConverter((value, writer) -> writer.writeString(Long.toString(value)))
+                .decimal128Converter((value, writer) -> writer.writeNumber(value.toString()))
+                .objectIdConverter((value, writer) -> writer.writeString(value.toString()))
+                .int32Converter((value, writer) -> writer.writeNumber(value.toString()))
+                .int64Converter((value, writer) -> writer.writeString(Long.toString(value)))
+                .build();
+
+        return jsonWriterSettings;
+    }
+
+
 }


### PR DESCRIPTION
异常现象：
在向mysql插入过程中，如果遇到SqlException异常。那么会放入脏数据处理。但是，SqlException没有打印出来，用户在日志中发现不了任何SqlException日志，无法及时排除问题。设计者应该是考虑到脏数据太大，导致日志文件过大，因此隐藏了错误日志。
但是，我认为默认还是应该把SqlException打印到日志文件中。
解决思路：
跟踪com.dtstack.flinkx.clickhouse.format.ClickhouseOutputFormat以及com.dtstack.flinkx.kudu.writer.KuduOutputFormat
这2个类在插入失败时都会把错误打印出来
LOG.error("Write data error, index = {}, row = {}, e = {}", index, row, ExceptionUtil.getErrorMessage(e));
因此，按照此方式进行打印错误日志