### PR TITLE
Add HADOOP conf to the classpath of the bootstrap class

### DIFF
--- a/bin/flinkx
+++ b/bin/flinkx
@@ -33,8 +33,21 @@ else
   fi
 fi
 
+# if neither HADOOP_CONF_DIR nor HADOOP_CLASSPATH are set, use some common default (if available)
+if [ -z "$HADOOP_CONF_DIR" ] && [ -z "$HADOOP_CLASSPATH" ]; then
+  if [ -d "/etc/hadoop/conf" ]; then
+      echo "Setting HADOOP_CONF_DIR=/etc/hadoop/conf because no HADOOP_CONF_DIR or HADOOP_CLASSPATH was set." >&2
+      HADOOP_CONF_DIR="/etc/hadoop/conf"
+  else
+    echo "HADOOP_CLASSPATH or HADOOP_CONF_DIR is not set" >&2
+    exit 1
+  fi
+fi
+
+INTERNAL_HADOOP_CLASSPATHS="${HADOOP_CLASSPATH}:${HADOOP_CONF_DIR}"
+
 JAR_DIR=$FLINKX_HOME/lib/*
 CLASS_NAME=com.dtstack.flinkx.launcher.Launcher
 
 echo "flinkx starting ..."
-nohup $JAVA_RUN -cp $JAR_DIR $CLASS_NAME $@ &
+nohup $JAVA_RUN -cp "$JAR_DIR:$INTERNAL_HADOOP_CLASSPATHS" $CLASS_NAME $@ &


### PR DESCRIPTION
Kerbero环境下，FlinkX 提交任务环境不能正确的加载 `hadoop.security.token.service.use_ip`=false，提交任务的 token 生成之后校验不通过，导致任务提交失败。

报错：
> java.io.IOException: Failed on local exception: java.io.IOException: org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]; Host Details : local host is: "hadoop-006.com/xxx.xx.xx.xx"; destination host is: "cdh.com":8020; 
	at org.apache.hadoop.net.NetUtils.wrapException(NetUtils.java:772)
	at org.apache.hadoop.ipc.Client.call(Client.java:1508)
	at org.apache.hadoop.ipc.Client.call(Client.java:1441)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:230)
	at com.sun.proxy.$Proxy11.getFileInfo(Unknown Source)
	at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:788)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:258)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:104)
	at com.sun.proxy.$Proxy12.getFileInfo(Unknown Source)
	at org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2168)
	at org.apache.hadoop.hdfs.DistributedFileSystem$20.doCall(DistributedFileSystem.java:1266)
	at org.apache.hadoop.hdfs.DistributedFileSystem$20.doCall(DistributedFileSystem.java:1262)
	at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
	at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1262)
	at org.apache.hadoop.yarn.util.FSDownload.copy(FSDownload.java:251)
	at org.apache.hadoop.yarn.util.FSDownload.access$000(FSDownload.java:61)
	at org.apache.hadoop.yarn.util.FSDownload$2.run(FSDownload.java:364)
	at org.apache.hadoop.yarn.util.FSDownload$2.run(FSDownload.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1924)
	at org.apache.hadoop.yarn.util.FSDownload.call(FSDownload.java:361)
	at org.apache.hadoop.yarn.util.FSDownload.call(FSDownload.java:60)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

可以两种方式来改变该属性，Flink 是用 （1） 的方式：

1. classpath 中添加 hadoop classpath 的环境变量，静态加载可以找到 core-site.xml 来设置 `useIpForTokenService` 属性；
2. 代码中通过调用 [org.apache.hadoop.security.SecurityUtil#setTokenServiceUseIp](https://github.com/apache/hadoop/blob/ec22850dbef852b1da24211e1bbdaabb18b01b1e/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/SecurityUtil.java#L122) 来设置；

参考 : [HADOOP-12954](https://issues.apache.org/jira/browse/HADOOP-12954)

FlinkX 和 flinkStreamSQL 应该都有这个问题。