### PR TITLE
[hotfix-356][flinkx-kafka] 修复kafkaState类 equals方法错误实现问题

### DIFF
--- a/flinkx-kb/flinkx-kb-core/src/main/java/com/dtstack/flinkx/kafkabase/entity/kafkaState.java
+++ b/flinkx-kb/flinkx-kb-core/src/main/java/com/dtstack/flinkx/kafkabase/entity/kafkaState.java
@@ -82,7 +82,7 @@ public class kafkaState implements Serializable {
                 timestamp.equals(that.timestamp) &&
                 partition.equals(that.partition) &&
                 topic.equals(that.topic);
-    }q
+    }
 
     @Override
     public kafkaState clone() {

--- a/flinkx-kb/flinkx-kb-core/src/main/java/com/dtstack/flinkx/kafkabase/entity/kafkaState.java
+++ b/flinkx-kb/flinkx-kb-core/src/main/java/com/dtstack/flinkx/kafkabase/entity/kafkaState.java
@@ -78,11 +78,11 @@ public class kafkaState implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         kafkaState that = (kafkaState) o;
-        return partition == that.partition &&
-                offset == that.offset &&
-                timestamp == that.timestamp &&
+        return offset.equals(that.offset) &&
+                timestamp.equals(that.timestamp) &&
+                partition.equals(that.partition) &&
                 topic.equals(that.topic);
-    }
+    }q
 
     @Override
     public kafkaState clone() {


### PR DESCRIPTION
kafkaState equals方法实现如下
```
// 类的成员变量
private String topic;
private Integer partition;
private Long offset;
private Long timestamp;

 @Override
    public boolean equals(Object o) {
        if (this == o) return true;
        if (o == null || getClass() != o.getClass()) return false;
        kafkaState that = (kafkaState) o;
        return partition == that.partition &&
                offset == that.offset &&
                timestamp == that.timestamp &&
                topic.equals(that.topic);
    }
```
按照我的理解， offset, timestamp的值按道理都不会存在Long对象的Cache中，也就是相同值的Long对象地址也会不同。 那么这里使用==去判断两者，导致的结果可能永远为False。 这里我认为应该实现为equals， 不知道我的理解是否正确， 还请指教
[issue](https://github.com/DTStack/flinkx/issues/356)