### PR TITLE
[flinkx-378] [kafka11]修复Kafka11Client错误的log4j日志类名

### DIFF
--- a/flinkx-kafka11/flinkx-kafka11-reader/src/main/java/com/dtstack/flinkx/kafka11/client/Kafka11Client.java
+++ b/flinkx-kafka11/flinkx-kafka11-reader/src/main/java/com/dtstack/flinkx/kafka11/client/Kafka11Client.java
@@ -25,7 +25,7 @@ import java.util.Properties;
  * @author tudou
  */
 public class Kafka11Client implements IClient {
-    private static Logger LOG = LoggerFactory.getLogger(Kafka11Consumer.class);
+    private static Logger LOG = LoggerFactory.getLogger(Kafka11Client.class);
     private volatile boolean running = true;
     private long pollTimeout;
     private boolean blankIgnore;


### PR DESCRIPTION
[flinkx-378] [kafka11]修复Kafka11Client错误的log4j日志类名 #379