### PR TITLE
[Docs] fix flinkx unzip folder name from 1.10_release to flinkx-1.10_release

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,7 +28,7 @@ cd flinkx
 ```
 wget https://github.com/DTStack/flinkx/archive/1.10_release.zip
 unzip 1.10_release.zip
-cd 1.10_release
+cd flinkx-1.10_release
 ```
 
 ## 编译插件


### PR DESCRIPTION
After unzip 1.10_release.zip, we got flinkx-1.10_release instead of 1.10_release.