### PR TITLE
[flinkx-394][kb] 解决earliest-offset不生效问题

### DIFF
--- a/flinkx-kb/flinkx-kb-core/src/main/java/com/dtstack/flinkx/kafkabase/util/KafkaUtil.java
+++ b/flinkx-kb/flinkx-kb-core/src/main/java/com/dtstack/flinkx/kafkabase/util/KafkaUtil.java
@@ -95,6 +95,7 @@ public class KafkaUtil {
         switch (mode){
             case EARLIEST:
                 props.put("auto.offset.reset", "earliest");
+                break;
             case LATEST:
                 props.put("auto.offset.reset", "latest");
         }


### PR DESCRIPTION
case语句后面添加break解决earliest-offset不生效问题 #394。
[如图：]
![image](https://user-images.githubusercontent.com/7700151/119333797-de09f480-bcbc-11eb-9480-d6acf65d0970.png)
