### PR TITLE
修改Bug: flinkx任务提交后，通过JobId不能获取到Flink任务信息。

### DIFF
--- a/flinkx-launcher/src/main/java/com/dtstack/flinkx/launcher/perJob/PerJobSubmitter.java
+++ b/flinkx-launcher/src/main/java/com/dtstack/flinkx/launcher/perJob/PerJobSubmitter.java
@@ -77,7 +77,8 @@ public class PerJobSubmitter {
         YarnClusterDescriptor descriptor = perJobClusterClientBuilder.createPerJobClusterDescriptor(launcherOptions);
         ClusterClientProvider<ApplicationId> provider = descriptor.deployJobCluster(clusterSpecification, jobGraph, true);
         String applicationId = provider.getClusterClient().getClusterId().toString();
-        String flinkJobId = jobGraph.getJobID().toString();
+        //use the real submitted JobGraph
+        String flinkJobId = descriptor.getJobGraph().getJobID().toString();
         LOG.info("deploy per_job with appId: {}}, jobId: {}", applicationId, flinkJobId);
         return applicationId;
     }

--- a/flinkx-launcher/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flinkx-launcher/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -123,6 +123,7 @@ import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetrieve
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.yarn.YarnConfigKeys.LOCAL_RESOURCE_DESCRIPTOR_SEPARATOR;
+import static org.apache.flink.runtime.jobgraph.JobGraph;
 
 /**
  * The descriptor with deployment information for deploying a Flink cluster on Yarn.
@@ -155,6 +156,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	private final String applicationType;
 
 	private String zookeeperNamespace;
+	/** save the submitted JobGraph*/
+	private JobGraph jobGraph;
 
 	private YarnConfigOptions.UserJarInclusion userJarInclusion;
 
@@ -224,6 +227,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 	public YarnClient getYarnClient() {
 		return yarnClient;
+	}
+
+	public JobGraph getJobGraph(){
+		return this.jobGraph;
 	}
 
 	/**

--- a/flinkx-launcher/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flinkx-launcher/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -566,6 +566,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			PackagedProgram program = FlinkPerJobUtil.buildProgram(url,clusterSpecification);
 			clusterSpecification.setProgram(program);
 			jobGraph = PackagedProgramUtils.createJobGraph(program, clusterSpecification.getConfiguration(), clusterSpecification.getParallelism(), false);
+			this.jobGraph = jobGraph;
 			String pluginLoadMode = clusterSpecification.getConfiguration().getString(ConfigConstant.FLINK_PLUGIN_LOAD_MODE_KEY);
 			if(StringUtils.equalsIgnoreCase(pluginLoadMode, ConstantValue.SHIP_FILE_PLUGIN_LOAD_MODE)){
 				jobGraph.getClasspaths().forEach(jarFile -> {


### PR DESCRIPTION
 flinkx任务提交后，通过JobId不能获取到Flink任务信息。
Bug产生原因:
 提交任务方法传入的JobGraph对象再方法内部重新创建了。