### PR TITLE
fix: MySQL BIGINT BigInteger to Long.

### DIFF
--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/converter/JdbcRowConverter.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/converter/JdbcRowConverter.java
@@ -127,7 +127,7 @@ public class JdbcRowConverter
             case INTERVAL_DAY_TIME:
             case INTEGER:
             case BIGINT:
-                return val -> val;
+                return val -> val instanceof BigInteger ? ((BigInteger)val).longValue() : val;
             case TINYINT:
                 return val -> ((Integer) val).byteValue();
             case SMALLINT:


### PR DESCRIPTION

解决 MySQL BIGINT 映射中 cannot cast to Long 问题。

Closes #477